### PR TITLE
v3.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+/vendor
+/composer.lock
+/.idea
+/.ddev
+/craft

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.3.0 - 2024-01-12
+
+### Added
+
+- You can now select what fields should be updated during a sync.
+- Added more API attributes to the list of fields that can be synchronized to Show entries.
+- Show Entry sync jobs can now sync the Passport availability and public availability flags.
+- The plugin now emits its own log files for better debugging.
+
+### Changed
+
+- **New** Media entries and Show entries added during a sync will always synchronize all fields, regardless of what fields were selected for sync.
+- The way a show's "Episode Count" property is determined now looks at a show's asset count rather than the static "Episode Count" property on the Show record.
+
 ## 3.2.0 - 2023-12-20
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "moon/pbs-media-manager-craft-gacraft",
   "description": "Media Manager 3 for PBS API",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "type": "craft-plugin",
   "keywords": ["craftcms", "pbs", "media-manager"],
   "license": "MIT",

--- a/src/MediaManager.php
+++ b/src/MediaManager.php
@@ -83,14 +83,21 @@ class MediaManager extends Plugin
         $this->registerBehaviors();
         $this->registerPluginServices();
 
-        Craft::info(
-            Craft::t(
-                'mediamanager',
-                '{name} plugin loaded',
-                [ 'name' => $this->name ]
-            ),
-            __METHOD__
-        );
+        $fileTarget = new \craft\log\FileTarget([
+            'logFile' => '@storage/logs/media-manager.log',
+            'categories' => ['papertiger\mediamanager\*'],
+            'enableRotation' => true,
+        ]);
+        Craft::getLogger()->dispatcher->targets[] = $fileTarget;
+
+        // ? ERROR LOG FILE
+        $errorTarget = new \craft\log\FileTarget([
+            'logFile' => '@storage/logs/media-manager-errors.log',
+            'categories' => ['papertiger\mediamanager\*'],
+            'levels' => ['error'],
+            'enableRotation' => true,
+        ]);
+        Craft::getLogger()->dispatcher->targets[] = $errorTarget;
     }
 
     public function beforeInstall(): bool

--- a/src/MediaManager.php
+++ b/src/MediaManager.php
@@ -265,6 +265,8 @@ class MediaManager extends Plugin
 			    foreach ($pushableSyncs as $pushableSync) {
 				    Craft::$app->getQueue()->push(new ShowSync([
 					    'showId' => $pushableSync->showId,
+							'regenerateThumbnails' => $pushableSync->regenerateThumbnail,
+					    'scheduledSync' => $pushableSync->id
 				    ]));
 						
 						$pushableSync->processed = 1;

--- a/src/assetbundles/synchronizecpsection/dist/js/Synchronize.js
+++ b/src/assetbundles/synchronizecpsection/dist/js/Synchronize.js
@@ -14,10 +14,10 @@
             init: function() {
             	var self = this;
 
-                this.addListener($('#syncrhonizeshowbtn'), 'activate', 'synchronizeShow');
-                this.addListener($('#syncrhonizesinglebtn'), 'activate', 'synchronizeSingle');
-                this.addListener($('#syncrhonizeallbtn'), 'activate', 'synchronizeAll');
-                this.addListener($('#syncrhonizeshowentriesbtn'), 'activate', 'synchronizeShowEntries');
+                this.addListener($('#synchronizeshowbtn'), 'activate', 'synchronizeShow');
+                this.addListener($('#synchronize-single-button'), 'activate', 'synchronizeSingle');
+                this.addListener($('#synchronize-all-button'), 'activate', 'synchronizeAll');
+                this.addListener($('#synchronize-show-entries-button'), 'activate', 'synchronizeShowEntries');
                 this.addListener($('#addshowsite'), 'activate', 'addShowSite');
                 this.addListener($('#cleanallbtn'), 'activate', 'cleanGarbageEntries');
 
@@ -39,9 +39,9 @@
             },
 
             deleteShowSite: function( target ) {
-                
+
                 if( $( 'select[name="siteId[]"]' ).length > 1 ) {
-                    
+
                     target.remove();
                     return
                 }
@@ -85,15 +85,20 @@
             	var showId   = $( '#showId' ).val()
             	var name     = $( '#name' ).val()
                 var forceRegenerateThumbnail = $( '#forceRegenerateThumbnail' ).prop( 'checked' )
+                var fieldsToSync = [];
+                var fieldsToSyncInputs = $('input[name="fieldsToSync[]"]:checked').each(function(index, field){
+                    fieldsToSync.push($(field).val());
+                })
 
         		if( showId ) {
-                    
+
                     var data = {
                         showId: showId,
-                        forceRegenerateThumbnail: forceRegenerateThumbnail
+                        forceRegenerateThumbnail: forceRegenerateThumbnail,
+                        fieldsToSync: fieldsToSync,
                     };
 
-                    $( '#syncrhonizeshowbtn' ).addClass( 'disabled' );
+                    $( '#synchronizeshowbtn' ).addClass( 'disabled' );
 
                     Craft.postActionRequest('mediamanager/synchronize/synchronize-show', data, $.proxy(function(response, textStatus) {
 
@@ -105,16 +110,16 @@
                                 }, 1000);
                             }
                             else if (response.errors) {
-                            	$( '#syncrhonizeshowbtn' ).removeClass( 'disabled' );
+                            	$( '#synchronizeshowbtn' ).removeClass( 'disabled' );
                                 var errors = this.flattenErrors(response.errors);
                                 Craft.cp.displayError(Craft.t('mediamanager', 'Could not start synchronize:') + "\n\n" + errors.join("\n") );
                             }
                             else {
-                            	$( '#syncrhonizeshowbtn' ).removeClass( 'disabled' );
+                            	$( '#synchronizeshowbtn' ).removeClass( 'disabled' );
                                 Craft.cp.displayError();
                             }
                         } else {
-                        	$( '#syncrhonizeshowbtn' ).removeClass( 'disabled' );
+                        	$( '#synchronizeshowbtn' ).removeClass( 'disabled' );
                         }
 
                     }, this));
@@ -135,6 +140,10 @@
             	var apiKey   = $( '#apiKey' ).val()
                 var siteId   = []
                 var forceRegenerateThumbnail = $( '#forceRegenerateThumbnail' ).prop( 'checked' )
+                var fieldsToSync = [];
+                var fieldsToSyncInputs = $('input[name="fieldsToSync[]"]:checked').each(function(index, field){
+                    fieldsToSync.push($(field).val());
+                })
 
                 $( 'select[name="siteId[]"]' ).each( function() {
 
@@ -146,14 +155,15 @@
                 })
 
         		if( apiKey && siteId ) {
-                    
+
                     var data = {
                         apiKey: apiKey,
                         siteId: siteId,
-                        forceRegenerateThumbnail: forceRegenerateThumbnail
+                        forceRegenerateThumbnail: forceRegenerateThumbnail,
+                        fieldsToSync: fieldsToSync,
                     };
 
-                    $( '#syncrhonizesinglebtn' ).addClass( 'disabled' );
+                    $( '#synchronize-single-button' ).addClass( 'disabled' );
 
                     Craft.postActionRequest('mediamanager/synchronize/synchronize-single', data, $.proxy(function(response, textStatus) {
 
@@ -165,16 +175,16 @@
                                 }, 1000);
                             }
                             else if (response.errors) {
-                            	$( '#syncrhonizesinglebtn' ).removeClass( 'disabled' );
+                            	$( '#synchronize-single-button' ).removeClass( 'disabled' );
                                 var errors = this.flattenErrors(response.errors);
                                 Craft.cp.displayError(Craft.t('mediamanager', 'Could not start synchronize:') + "\n\n" + errors.join("\n") );
                             }
                             else {
-                            	$( '#syncrhonizesinglebtn' ).removeClass( 'disabled' );
+                            	$( '#synchronize-single-button' ).removeClass( 'disabled' );
                                 Craft.cp.displayError();
                             }
                         } else {
-                        	$( '#syncrhonizesinglebtn' ).removeClass( 'disabled' );
+                        	$( '#synchronize-single-button' ).removeClass( 'disabled' );
                         }
 
                     }, this));
@@ -186,11 +196,20 @@
 
             synchronizeAll: function() {
 
-                $( '#syncrhonizeallbtn' ).addClass( 'disabled' );
+                $( '#synchronize-all-button' ).addClass( 'disabled' );
 
                 var forceRegenerateThumbnail = $( '#forceRegenerateThumbnail' ).prop( 'checked' )
+                var fieldsToSync = [];
+                var fieldsToSyncInputs = $('input[name="fieldsToSync[]"]:checked').each(function(index, field){
+                    fieldsToSync.push($(field).val());
+                })
 
-                Craft.postActionRequest('mediamanager/synchronize/synchronize-all?forceRegenerateThumbnail=' + forceRegenerateThumbnail, {}, $.proxy(function(response, textStatus) {
+                var data = {
+                    forceRegenerateThumbnail: forceRegenerateThumbnail,
+                    fieldsToSync: fieldsToSync,
+                };
+
+                Craft.postActionRequest('mediamanager/synchronize/synchronize-all', data, $.proxy(function(response, textStatus) {
 
                     if (textStatus === 'success') {
                         if (response.success) {
@@ -200,16 +219,16 @@
                             }, 1000);
                         }
                         else if (response.errors) {
-                        	$( '#syncrhonizeallbtn' ).removeClass( 'disabled' );
+                        	$( '#synchronize-all-button' ).removeClass( 'disabled' );
                             var errors = this.flattenErrors(response.errors);
                             Craft.cp.displayError(Craft.t('mediamanager', 'Could not start synchronize:') + "\n\n" + errors.join("\n") );
                         }
                         else {
-                        	$( '#syncrhonizeallbtn' ).removeClass( 'disabled' );
+                        	$( '#synchronize-all-button' ).removeClass( 'disabled' );
                             Craft.cp.displayError();
                         }
                     } else {
-                    	$( '#syncrhonizeallbtn' ).removeClass( 'disabled' );
+                    	$( '#synchronize-all-button' ).removeClass( 'disabled' );
                     }
 
                 }, this));
@@ -217,9 +236,18 @@
 
             synchronizeShowEntries: function() {
 
-                $( '#syncrhonizeshowentriesbtn' ).addClass( 'disabled' );
+                $( '#synchronize-show-entries-button' ).addClass( 'disabled' );
 
-                Craft.postActionRequest('mediamanager/synchronize/synchronize-show-entries', {}, $.proxy(function(response, textStatus) {
+                var fieldsToSync = [];
+                var fieldsToSyncInputs = $('input[name="fieldsToSync[]"]:checked').each(function(index, field){
+                    fieldsToSync.push($(field).val());
+                })
+
+                var data = {
+                    fieldsToSync: fieldsToSync,
+                };
+
+                Craft.postActionRequest('mediamanager/synchronize/synchronize-show-entries', data, $.proxy(function(response, textStatus) {
 
                     if (textStatus === 'success') {
                         if (response.success) {
@@ -229,16 +257,16 @@
                             }, 1000);
                         }
                         else if (response.errors) {
-                            $( '#syncrhonizeshowentriesbtn' ).removeClass( 'disabled' );
+                            $( '#synchronize-show-entries-button' ).removeClass( 'disabled' );
                             var errors = this.flattenErrors(response.errors);
                             Craft.cp.displayError(Craft.t('mediamanager', 'Could not start synchronize:') + "\n\n" + errors.join("\n") );
                         }
                         else {
-                            $( '#syncrhonizeshowentriesbtn' ).removeClass( 'disabled' );
+                            $( '#synchronize-show-entries-button' ).removeClass( 'disabled' );
                             Craft.cp.displayError();
                         }
                     } else {
-                        $( '#syncrhonizeshowentriesbtn' ).removeClass( 'disabled' );
+                        $( '#synchronize-show-entries-button' ).removeClass( 'disabled' );
                     }
 
                 }, this));

--- a/src/controllers/ScheduledSyncController.php
+++ b/src/controllers/ScheduledSyncController.php
@@ -98,6 +98,13 @@
 			$scheduledSync->scheduleDate = DateTimeHelper::toDateTime($scheduledSync->scheduleDate);
 			$scheduledSync->showId = $request->getBodyParam('showId');
 			
+			$mediaFieldsToSync = $request->getBodyParam('mediaFieldsToSync');
+			$showFieldsToSync = $request->getBodyParam('showFieldsToSync');
+			
+			$scheduledSync->mediaFieldsToSync = $mediaFieldsToSync === '*' ? '*' : join(',', $mediaFieldsToSync);
+			$scheduledSync->showFieldsToSync = $showFieldsToSync === '*' ? '*' : join(',', $showFieldsToSync);
+			$scheduledSync->regenerateThumbnail = $request->getBodyParam('forceRegenerateThumbnail') ?? false;
+			
 			if(!MediaManager::getInstance()->scheduledSync->saveScheduledSync($scheduledSync)) {
 				Craft::$app->getSession()->setError(Craft::t('mediamanager', 'Couldn’t save scheduled sync.'));
 				Craft::$app->getUrlManager()->setRouteParams([

--- a/src/controllers/SynchronizeController.php
+++ b/src/controllers/SynchronizeController.php
@@ -121,7 +121,8 @@ class SynchronizeController extends Controller
         $showId  = $request->getBodyParam( 'showId' );
         $siteId  = $request->getBodyParam( 'siteId' );
         $forceRegenerateThumbnail  = $request->getBodyParam( 'forceRegenerateThumbnail' );
-
+				$fieldsToSync = $request->getBodyParam('fieldsToSync');
+				
         if( !$showId ) {
 
             return $this->asJson([
@@ -144,7 +145,7 @@ class SynchronizeController extends Controller
             ]);
         }
 
-        $synchronize = MediaManager::getInstance()->api->synchronizeShow( $show, $forceRegenerateThumbnail );
+        $synchronize = MediaManager::getInstance()->api->synchronizeShow( $show, $forceRegenerateThumbnail, $fieldsToSync );
 
         return $this->asJson([
             'success' => true
@@ -158,6 +159,7 @@ class SynchronizeController extends Controller
         $apiKey  = $request->getBodyParam( 'apiKey' );
         $siteId  = $request->getBodyParam( 'siteId' );
         $forceRegenerateThumbnail = $request->getBodyParam( 'forceRegenerateThumbnail' );
+				$fieldsToSync = $request->getBodyParam('fieldsToSync');
 
         if( !$apiKey || !$siteId ) {
 
@@ -179,7 +181,7 @@ class SynchronizeController extends Controller
             }
         }
 
-        $synchronize = MediaManager::getInstance()->api->synchronizeSingle( $apiKey, $siteId, $forceRegenerateThumbnail );
+        $synchronize = MediaManager::getInstance()->api->synchronizeSingle( $apiKey, $siteId, $forceRegenerateThumbnail, $fieldsToSync );
 
         return $this->asJson([
             'success' => true
@@ -191,8 +193,9 @@ class SynchronizeController extends Controller
         $shows = MediaManager::getInstance()->show->getShow();
         $validatedShows = [];
         $request = Craft::$app->getRequest();
-        $forceRegenerateThumbnail  = $request->getQueryParam( 'forceRegenerateThumbnail' );
-
+	      $forceRegenerateThumbnail = $request->getBodyParam( 'forceRegenerateThumbnail' );
+				$fieldsToSync = $request->getBodyParam('fieldsToSync');
+	      
         foreach( $shows as $show ) {
             
             if( $show->apiKey && $show->name ) {
@@ -210,7 +213,7 @@ class SynchronizeController extends Controller
             ]);
         }
 
-        $synchronize = MediaManager::getInstance()->api->synchronizeAll( $validatedShows, $forceRegenerateThumbnail );
+        $synchronize = MediaManager::getInstance()->api->synchronizeAll( $validatedShows, $forceRegenerateThumbnail, $fieldsToSync );
 
         return $this->asJson([
             'success' => true
@@ -239,8 +242,10 @@ class SynchronizeController extends Controller
                 'errors' => [ 'No valid Show API Key registered, please register one.' ],
             ]);
         }
-
-        $synchronize = MediaManager::getInstance()->api->synchronizeShowEntries( $validatedShows );
+	
+	      $fieldsToSync = $request->getBodyParam('fieldsToSync');
+				
+        $synchronize = MediaManager::getInstance()->api->synchronizeShowEntries( $validatedShows, $fieldsToSync);
 
         return $this->asJson([
             'success' => true

--- a/src/jobs/ShowEntriesSync.php
+++ b/src/jobs/ShowEntriesSync.php
@@ -12,6 +12,9 @@ namespace papertiger\mediamanager\jobs;
 
 use Craft;
 use craft\db\Query;
+use craft\errors\ElementNotFoundException;
+use craft\helpers\DateTimeHelper;
+use craft\helpers\Json;
 use craft\queue\BaseJob;
 use craft\elements\Entry;
 use craft\elements\Asset;
@@ -20,9 +23,11 @@ use craft\helpers\FileHelper;
 use craft\helpers\ElementHelper;
 use craft\helpers\Assets as AssetHelper;
 
+use DateTime;
 use papertiger\mediamanager\MediaManager;
 use papertiger\mediamanager\helpers\SettingsHelper;
 use papertiger\mediamanager\helpers\SynchronizeHelper;
+use yii\base\Exception;
 
 
 class ShowEntriesSync extends BaseJob
@@ -58,12 +63,20 @@ class ShowEntriesSync extends BaseJob
     // =========================================================================
     
     private $dateWithMs = 'Y-m-d\TH:i:s.uP';
-
+		
+		private $_availabilityProcessed = false;
+		private $availabilityPassport = 0;
+		private $availabilityPublic = 0;
 
     // Public Methods
     // =========================================================================
-
-    public function execute( $queue )
+	
+	/**
+	 * @throws Exception
+	 * @throws \Throwable
+	 * @throws ElementNotFoundException
+	 */
+	public function execute( $queue )
     {
         $this->apiBaseUrl     = SettingsHelper::get( 'apiBaseUrl' );
         $this->sectionId      = SynchronizeHelper::getShowSectionId(); // SECTION_ID
@@ -75,11 +88,12 @@ class ShowEntriesSync extends BaseJob
         $this->logFile        = '@storage/logs/sync.log'; // LOG_FILE
 
         $url      = $this->generateAPIUrl( $this->apiKey );
-        $showEntry = $this->fetchShowEntry( $url );
+        $showEntry = $this->fetchShowEntry($url, '');
+				
+        $showAttributes = $showEntry->data->attributes;
 
-        $showAttributes = $showEntry->attributes;
-
-        $existingEntry       = $this->findExistingShowEntry( $showEntry->id );
+        $existingEntry       = $this->findExistingShowEntry( $showEntry->data->id );
+				$isNew = !$existingEntry;
         $entry               = $this->chooseOrCreateShowEntry( $showAttributes->title, $existingEntry );
 
         // Set default field Values
@@ -93,7 +107,7 @@ class ShowEntriesSync extends BaseJob
             $apiField = $apiColumnField[ 0 ];
 	
 		        // ensure the field to be updated from MM Settings is included in the fieldsToSync array
-		        if($this->fieldsToSync !== '*' && !in_array($apiField, $this->fieldsToSync) ) {
+		        if(!$isNew && ($this->fieldsToSync !== '*' && !in_array($apiField, $this->fieldsToSync))) {
 			        continue;
 		        }
 
@@ -147,8 +161,32 @@ class ShowEntriesSync extends BaseJob
                     $defaultFields[ SynchronizeHelper::getShowLastSyncedField() ] = new \DateTime( 'now' );
                 break;
                 case 'show_media_manager_id':
-                    $defaultFields[ SynchronizeHelper::getShowMediaManagerIdField() ] = $showEntry->id;
+                    $defaultFields[ SynchronizeHelper::getShowMediaManagerIdField() ] = $showEntry->data->id;
                 break;
+	              case 'show_site_url':
+									if(isset( $showAttributes->links) && is_array($showAttributes->links)){
+                        foreach($showAttributes->links as $link) {
+                            if($link->profile == 'producer') {
+																$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $link->value;
+														}
+                        }
+                    }
+								break;
+	              case 'available_for_purchase':
+									$availableForPurchase = 0;
+									$purchasablePlatforms = ['itunes', 'amazon', 'buy-dvd', 'roku', 'apple-tv', 'ios'];
+									if(isset( $showAttributes->links) && is_array($showAttributes->links)){
+                        foreach($showAttributes->links as $link) {
+                            if($availableForPurchase || !in_array($link->profile, $purchasablePlatforms)){
+																continue;
+                            }
+														if(in_array($link->profile, $purchasablePlatforms)){
+																$availableForPurchase = 1;
+														}
+                        }
+												$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $availableForPurchase;
+                    }
+								break;
                 case 'description_long':
                     // Only if new entry add description
                     if( !$existingEntry ) {
@@ -172,7 +210,6 @@ class ShowEntriesSync extends BaseJob
                         $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $showAttributes->episodes_count;
                     }
                 break;
-
                 case 'featured_preview':
 
                     $mediaManagerEntries = [];
@@ -185,7 +222,6 @@ class ShowEntriesSync extends BaseJob
                     }
 
                 break;
-
                 case 'links':
 
                     if( isset( $showAttributes->links ) && is_array( $showAttributes->links ) ) {
@@ -205,33 +241,16 @@ class ShowEntriesSync extends BaseJob
                     }
 
                 break;
-										
-                case 'show_site_url':
-                    if(isset( $showAttributes->links) && is_array($showAttributes->links)){
-                        foreach($showAttributes->links as $link) {
-                            if($link->profile == 'producer') {
-                                $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $link->value;
-                            }
-                        }
-                    }
-								break;
-
-                case 'available_for_purchase':
-                    $availableForPurchase = 0;
-                    $purchasablePlatforms = ['itunes', 'amazon', 'buy-dvd', 'roku', 'apple-tv', 'ios'];
-                    if(isset( $showAttributes->links) && is_array($showAttributes->links)){
-                        foreach($showAttributes->links as $link) {
-                            if($availableForPurchase || !in_array($link->profile, $purchasablePlatforms)){
-                                continue;
-                            }
-                            if(in_array($link->profile, $purchasablePlatforms)){
-                                $availableForPurchase = 1;
-                            }
-                        }
-                        $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $availableForPurchase;
-                    }
-                    break;
-
+	              case 'stream_with_passport':
+									$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $this->getShowAvailability('availabilityPassport', $showEntry);
+									break;
+									
+		            case 'available_to_public':
+									$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $this->getShowAvailability('availabilityPublic', $showEntry);
+									break;
+									
+								
+									
                 default:
                     $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $showAttributes->{ $apiField };
                 break;
@@ -270,14 +289,93 @@ class ShowEntriesSync extends BaseJob
         return $this->apiBaseUrl . 'shows/'. $apiKey . '/?platform-slug=bento&platform-slug=partnerplayer';
     }
 
-    private function fetchShowEntry( $url )
+    private function fetchShowEntry($url, $attribute = 'data')
     {
         $client   = Craft::createGuzzleClient();
         $response = $client->get( $url, $this->auth );
-        $response = json_decode( $response->getBody() );
+        $response = Json::decode($response->getBody(), false);
 
-        return $response->data;
+        if($attribute){
+					return $response->{$attribute};
+				}
+				
+        return $response;
     }
+	
+	/**
+	 * @throws \Exception
+	 */
+	private function getShowAvailability(string $attribute, $showEntry): int
+		{
+			// Don't run this twice
+			if($this->_availabilityProcessed){
+				return $this->$attribute;
+			}
+			
+			// There is probably a much cleaner / more straightforward way of doing this
+			// we need to loops through all assets of the show's first season to see if any of them are available for streaming
+			// If any episode in season 1 is available to passport members, then we can say the show is in Passport. If any episode within Season 1 is available to the Public, then we can also say it is "available to everyone".
+			// logic per https://github.com/pbs/pbs-media-manager-craft-plugin/issues/10#issuecomment-1791521258
+			
+			$availableOnPassport = 0;
+			$availableToPublic = 0;
+			
+      // get show's seasons
+      $seasonsUrl = $showEntry->links->seasons;
+      $seasonData = $this->fetchShowEntry($seasonsUrl);
+			if(!$seasonData){
+				 Craft::error('No seasons found for show ' . $showEntry->data->id, __METHOD__);
+				return 0;
+			}
+			
+			// get first season's episodes
+			$firstSeasonIndex = count($seasonData) - 1;
+			$episodesUrl = $seasonData[$firstSeasonIndex]->links->episodes;
+			$episodesData = $this->fetchShowEntry($episodesUrl);
+			
+			if(!$episodesData){
+				Craft::error('No episodes found for season ' . $seasonData[$firstSeasonIndex]->id, __METHOD__);
+				return 0;
+			}
+			
+			foreach($episodesData as $episode){
+				// if we've determined that both are true, we can stop looping
+				if($availableOnPassport && $availableToPublic){
+					continue;
+				}
+				
+				$episodeAssetsUrl = $episode->links->assets;
+				$episodeAssets = $this->fetchShowEntry($episodeAssetsUrl);
+				
+				if(!$episodeAssets) {
+					Craft::error('No assets found for episode ' . $episode->id, __METHOD__);
+					return 0;
+				}
+				
+				foreach($episodeAssets as $asset){
+					if($availableOnPassport && $availableToPublic){
+						continue;
+					}
+					
+					$publicEndDate = new DateTime($asset->attributes->availabilities->public->end) ?? null;
+					$passportEndDate = new DateTime($asset->attributes->availabilities->all_members->end) ?? null;
+					
+					if($publicEndDate instanceof DateTime){
+						$availableToPublic = DateTimeHelper::isInThePast($publicEndDate) ? 0 : 1;
+					}
+					
+					if($passportEndDate instanceof DateTime){
+						$availableOnPassport = DateTimeHelper::isInThePast($passportEndDate) ? 0 : 1;
+					}
+				}
+			}
+			
+			$this->availabilityPassport = $availableOnPassport;
+			$this->availabilityPublic = $availableToPublic;
+			$this->_availabilityProcessed = true;
+			
+			return $this->$attribute;
+		}
     
     private function findExistingShowEntry( $mediaManagerId )
     {

--- a/src/jobs/ShowEntriesSync.php
+++ b/src/jobs/ShowEntriesSync.php
@@ -205,10 +205,20 @@ class ShowEntriesSync extends BaseJob
                     }
                 break;
                 case 'episodes_count':
-                    // Retain Episodes Count for existing entries
-                    if( !$existingEntry ) {
-                        $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $showAttributes->episodes_count;
+
+                    // legacy count
+                    $episodesCount = $showAttributes->episodes_count;
+                    // see here for context: https://github.com/pbs/pbs-media-manager-craft-plugin/issues/11#issuecomment-1850786717
+
+                    $assetsData = $this->fetchShowEntry($this->apiBaseUrl . 'assets', 'data',
+                        ['show-id' => $this->apiKey, 'type' => 'full_length', 'parent-type' => 'episode']);
+
+                    if($assetsData){
+                        $episodesCount = count($assetsData);
                     }
+
+                    $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $episodesCount;
+
                 break;
                 case 'featured_preview':
 
@@ -289,10 +299,16 @@ class ShowEntriesSync extends BaseJob
         return $this->apiBaseUrl . 'shows/'. $apiKey . '/?platform-slug=bento&platform-slug=partnerplayer';
     }
 
-    private function fetchShowEntry($url, $attribute = 'data')
+    private function fetchShowEntry($url, $attribute = 'data', $params = [])
     {
         $client   = Craft::createGuzzleClient();
-        $response = $client->get( $url, $this->auth );
+        $options = $this->auth;
+
+        if($params){
+          $options = array_merge($options, ['query' => $params]);
+        }
+
+        $response = $client->get($url, $options);
         $response = Json::decode($response->getBody(), false);
 
         if($attribute){
@@ -345,11 +361,10 @@ class ShowEntriesSync extends BaseJob
 				}
 				
 				$episodeAssetsUrl = $episode->links->assets;
-				$episodeAssets = $this->fetchShowEntry($episodeAssetsUrl);
 				
+				$episodeAssets = $this->fetchShowEntry($episodeAssetsUrl, 'data', ['type' => 'full_length']);
 				if(!$episodeAssets) {
-					Craft::error('No assets found for episode ' . $episode->id, __METHOD__);
-					return 0;
+					continue;
 				}
 				
 				foreach($episodeAssets as $asset){

--- a/src/jobs/ShowEntriesSync.php
+++ b/src/jobs/ShowEntriesSync.php
@@ -150,6 +150,34 @@ class ShowEntriesSync extends BaseJob
                         $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $showAttributes->description_short;
                     }
                 break;
+										
+                case 'show_site_url':
+									if(isset( $showAttributes->links) && is_array($showAttributes->links)){
+                        foreach($showAttributes->links as $link) {
+                            if($link->profile == 'producer') {
+																$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $link->value;
+														}
+                        }
+                    }
+								break;
+
+	              case 'available_for_purchase':
+									$availableForPurchase = 0;
+									$purchasablePlatforms = ['itunes', 'amazon', 'buy-dvd', 'roku', 'apple-tv', 'ios'];
+									if(isset( $showAttributes->links) && is_array($showAttributes->links)){
+                        foreach($showAttributes->links as $link) {
+                            if($availableForPurchase || !in_array($link->profile, $purchasablePlatforms)){
+																continue;
+                            }
+														if(in_array($link->profile, $purchasablePlatforms)){
+																$availableForPurchase = 1;
+														}
+                        }
+												$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $availableForPurchase;
+                    }
+								break;
+
+               
 
                 default:
                     $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $showAttributes->{ $apiField };
@@ -175,9 +203,9 @@ class ShowEntriesSync extends BaseJob
 
     // Private Methods
     // =========================================================================
-     
+    
     private function log( $message )
-    {   
+    {
         if( $this->logProcess ) {
             $log = date( 'Y-m-d H:i:s' ) .' '. $message . "\n";
             FileHelper::writeToFile( Craft::getAlias( $this->logFile ), $log, [ 'append' => true ] );

--- a/src/jobs/ShowSync.php
+++ b/src/jobs/ShowSync.php
@@ -34,6 +34,16 @@
 		 */
 		public $showId;
 		
+		/**
+		 * @var int
+		 */
+		public $scheduledSync;
+		
+		/**
+		 * @var bool
+		 */
+		public $regenerateThumbnails;
+		
 		public $_show;
 		
 		// Public Methods
@@ -42,7 +52,12 @@
 		public function execute( $queue )
 		{
 			$show = $this->_getShow();
-			MediaManager::$plugin->api->synchronizeShow($show, false);
+			$scheduledSync = MediaManager::getInstance()->scheduledSync->getScheduledSyncById($this->scheduledSync);
+			$mediaFieldsToSync = $scheduledSync->getMediaFieldsToSync();
+			$showFieldsToSync = $scheduledSync->getShowFieldsToSync();
+			
+			MediaManager::$plugin->api->synchronizeShow($show, $this->regenerateThumbnails, $mediaFieldsToSync);
+			MediaManager::$plugin->api->synchronizeShowEntries([$show], $showFieldsToSync);
 		}
 		
 		// Protected Methods

--- a/src/migrations/m231102_150246_update_scheduled_sync_table.php
+++ b/src/migrations/m231102_150246_update_scheduled_sync_table.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace papertiger\mediamanager\migrations;
+
+use Craft;
+use craft\db\Migration;
+use papertiger\mediamanager\base\ConstantAbstract;
+
+/**
+ * m231102_150244_update_scheduled_sync_table migration.
+ */
+
+class m231102_150246_update_scheduled_sync_table extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+		
+		private $scheduledSyncTable = ConstantAbstract::MEDIAMANAGER_SCHEDULED_SYNC_TABLE;
+    public function safeUp()
+    {
+        $scheduledSyncTable = Craft::$app->db->schema->getTableSchema($this->scheduledSyncTable);
+				
+				if(!$scheduledSyncTable){
+					echo "No scheduled sync table found.\n";
+					return false;
+				}
+				
+				echo "Updating scheduled sync table…\n";
+				
+				if(!$scheduledSyncTable->getColumn('mediaFieldsToSync')){
+					$this->addColumn($this->scheduledSyncTable, 'mediaFieldsToSync', $this->text());
+				}
+				if(!$scheduledSyncTable->getColumn('showFieldsToSync')){
+					$this->addColumn($this->scheduledSyncTable, 'showFieldsToSync', $this->text());
+				}
+				
+				if(!$scheduledSyncTable->getColumn('regenerateThumbnail')){
+					$this->addColumn($this->scheduledSyncTable, 'regenerateThumbnail', $this->boolean());
+				}
+				
+				echo "Finished!\n";
+				
+				return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m231102_150244_update_scheduled_sync_table cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/ScheduledSyncModel.php
+++ b/src/models/ScheduledSyncModel.php
@@ -34,6 +34,16 @@ class ScheduledSyncModel extends BaseModel
 	public $showId;
 	
 	/**
+	 * @var string
+	 */
+	public $mediaFieldsToSync;
+	
+	/**
+	 * @var string
+	 */
+	public $showFieldsToSync;
+	
+	/**
 	 * @var DateTime Schedule Date
 	 */
 	public $scheduleDate;
@@ -42,6 +52,11 @@ class ScheduledSyncModel extends BaseModel
 	 * @var bool Processed
 	 */
 	public $processed;
+	
+	/**
+	 * @var bool
+	 */
+	public $regenerateThumbnail;
 	
 	public function __toString()
 	{
@@ -70,5 +85,18 @@ class ScheduledSyncModel extends BaseModel
 	{
 		return UrlHelper::cpUrl('mediamanager/scheduler/' . $this->id);
 	}
+	
+	/**
+	 * @return array|string
+	 */
+	public function getMediaFieldsToSync()
+	{
+		return $this->mediaFieldsToSync === '*' ? '*' : explode(',', $this->mediaFieldsToSync);
+	}
+	public function getShowFieldsToSync()
+	{
+		return $this->showFieldsToSync === '*' ? '*' : explode(',', $this->showFieldsToSync);
+	}
+	
 	
 }

--- a/src/records/ScheduledSyncRecord.php
+++ b/src/records/ScheduledSyncRecord.php
@@ -26,6 +26,9 @@
 	 * @property int $id ID
 	 * @property DateTime $scheduleDate Schedule Date
 	 * @property bool $processed Processed
+	 * @property string $mediaFieldsToSync
+	 * @property string $showFieldsToSync
+	 * @property bool $regenerateThumbnail
 	 */
 	class ScheduledSyncRecord extends ActiveRecord
 	{

--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -100,19 +100,19 @@ class Api extends Component
         return false;
     }
 
-    public function synchronizeShow( $show, $forceRegenerateThumbnail )
+    public function synchronizeShow( $show, $forceRegenerateThumbnail, $fieldsToSync ): bool
     {
 
         if( !$show->apiKey ) {
             return false;
         }
 
-        $this->runSynchronizeShow( $show, $forceRegenerateThumbnail );
+        $this->runSynchronizeShow( $show, $forceRegenerateThumbnail, $fieldsToSync );
 
         return true;
     }
 
-    public function synchronizeSingle( $apiKey, $siteId, $forceRegenerateThumbnail )
+    public function synchronizeSingle( $apiKey, $siteId, $forceRegenerateThumbnail, $fieldsToSync = '*' )
     {
 
         if( !$apiKey || !$siteId ) {
@@ -125,25 +125,26 @@ class Api extends Component
             'singleAssetKey' => $apiKey,
             'title'          => 'Single media asset',
             'auth'           => self::$apiAuth,
-            'forceRegenerateThumbnail' => $forceRegenerateThumbnail
+            'forceRegenerateThumbnail' => $forceRegenerateThumbnail,
+	          'fieldsToSync' => $fieldsToSync
         ]));
 
         return true;
     }
 
-    public function synchronizeAll( $shows, $forceRegenerateThumbnail )
+    public function synchronizeAll( $shows, $forceRegenerateThumbnail, $fieldsToSync = '*' )
     {
         foreach( $shows as $show ) {
             
             if( $show->apiKey ) {
-                $this->runSynchronizeShow( $show, $forceRegenerateThumbnail );
+                $this->runSynchronizeShow( $show, $forceRegenerateThumbnail, $fieldsToSync );
             }
         }
 
         return true;
     }
 
-    public function synchronizeShowEntries( $shows )
+    public function synchronizeShowEntries( $shows, $fieldsToSync = '*' )
     {
         foreach( $shows as $show ) {
             
@@ -153,7 +154,8 @@ class Api extends Component
 
                     'apiKey'      => $show->apiKey,
                     'title'       => $show->name . ' (Show)',
-                    'auth'        => self::$apiAuth
+                    'auth'        => self::$apiAuth,
+	                  'fieldsToSync' => $fieldsToSync,
                 ]));
             }
         }
@@ -328,7 +330,7 @@ class Api extends Component
     // Private Methods
     // =========================================================================
     
-    private function runSynchronizeShow( $show, $forceRegenerateThumbnail )
+    private function runSynchronizeShow( $show, $forceRegenerateThumbnail, $fieldsToSync = '*' )
     {
         Craft::$app->queue->push( new MediaSync([
 
@@ -338,7 +340,8 @@ class Api extends Component
             'apiKey'      => $show->apiKey,
             'title'       => $show->name . ' (Show)',
             'auth'        => self::$apiAuth,
-            'forceRegenerateThumbnail' => $forceRegenerateThumbnail
+            'forceRegenerateThumbnail' => $forceRegenerateThumbnail,
+	          'fieldsToSync' => $fieldsToSync
         ]));
 
         $seasons = $this->getSeasonsOfShow( $show->apiKey );
@@ -355,7 +358,8 @@ class Api extends Component
                 'apiKey'      => $season->id,
                 'title'       => $show->name . ' (Season ' . $season->attributes->ordinal . ')',
                 'auth'        => self::$apiAuth,
-                'forceRegenerateThumbnail' => $forceRegenerateThumbnail
+                'forceRegenerateThumbnail' => $forceRegenerateThumbnail,
+	              'fieldsToSync' => $fieldsToSync
             ]));
 
             $episodes = $this->getEpisodesOfShow( $season->id );
@@ -372,7 +376,8 @@ class Api extends Component
                     'apiKey'      => $episode->id,
                     'title'       => $episode->attributes->title . ' (Episode)',
                     'auth'        => self::$apiAuth,
-                    'forceRegenerateThumbnail' => $forceRegenerateThumbnail
+                    'forceRegenerateThumbnail' => $forceRegenerateThumbnail,
+	                  'fieldsToSync' => $fieldsToSync
                 ]));
             }
         }
@@ -391,7 +396,8 @@ class Api extends Component
                 'apiKey'      => $special->id,
                 'title'       => $special->attributes->title . ' (Special)',
                 'auth'        => self::$apiAuth,
-                'forceRegenerateThumbnail' => $forceRegenerateThumbnail
+                'forceRegenerateThumbnail' => $forceRegenerateThumbnail,
+	              'fieldsToSync' => $fieldsToSync
             ]));
         }
     }

--- a/src/templates/scheduler/_edit.twig
+++ b/src/templates/scheduler/_edit.twig
@@ -78,6 +78,61 @@
 {#			details: 'The date and time to run the sync.'|t('mediamanager'),#}
 {#		}, datetimeInput) }}#}
 
+		{{ forms.checkboxField({
+        first: false,
+        label: "Force regenerate thumbnail"|t('media-manager'),
+        instructions: "System will replace existing thumbnail if Media Asset already exists."|t('media-manager'),
+        id: 'forceRegenerateThumbnail',
+        name: 'forceRegenerateThumbnail',
+				value: 1,
+				checked: scheduledSync.regenerateThumbnail,
+        errors: '',
+        autofocus: true,
+        required: false,
+    }) }}
+
+		{% set apiColumnFields = craft.app.getPlugins().getPlugin('mediamanager').getSettings().apiColumnFields %}
+
+    {% set fieldsToSyncMap = {
+	    'title': 'Title'
+    } %}
+
+    {% for apiColumnField in apiColumnFields %}
+        {% set fieldsToSyncMap = fieldsToSyncMap|merge({(apiColumnField[0]): apiColumnField[2]}) %}
+    {% endfor %}
+
+    {{ forms.checkboxSelectField({
+        id: 'mediaFieldsToSync',
+        name: 'mediaFieldsToSync',
+        label: 'Media Fields to Sync',
+        showAllOption: true,
+        options: fieldsToSyncMap,
+        values: scheduledSync.getMediaFieldsToSync() ?? '*',
+        instructions: 'Choose which media entry fields you would like to be updated during this sync.',
+    }) }}
+
+		{% set fieldsToSyncMap = {} %}
+
+    {% set apiColumnFields = craft.app.getPlugins().getPlugin( 'mediamanager' ).getSettings().showApiColumnFields %}
+
+    {% for apiColumnField in apiColumnFields %}
+        {% set title = apiColumnField[2] %}
+        {% if title == '' %}
+            {% set title = apiColumnField[1] %}
+        {% endif %}
+        {% set fieldsToSyncMap = fieldsToSyncMap|merge({(apiColumnField[0]): title}) %}
+    {% endfor %}
+
+    {{ forms.checkboxSelectField({
+        id: 'showFieldsToSync',
+        name: 'showFieldsToSync',
+        label: 'Show Fields to Sync',
+        showAllOption: true,
+        options: fieldsToSyncMap,
+        values:  scheduledSync.getShowFieldsToSync() ?? '*',
+        instructions: 'Choose which show fields you would like to be updated during this sync.',
+    }) }}
+
 		{% set showOptions = [] %}
 		{% for show in shows %}
 			{% set showOptions = showOptions|merge([{label: show.name, value: show.id}]) %}

--- a/src/templates/settings/_apicolumnfields.twig
+++ b/src/templates/settings/_apicolumnfields.twig
@@ -153,6 +153,14 @@
                         "label":"links"
                     },
                     {
+                        "value": "stream_with_passport",
+                        "label": "Stream with Passport (bool)"
+                    },
+                    {
+                        "value": "available_to_public",
+                        "label": "Available to Public (bool)"
+                    },
+                    {
                         "value":"featured_preview",
                         "label":"featured_preview"
                     },

--- a/src/templates/settings/_apicolumnfields.twig
+++ b/src/templates/settings/_apicolumnfields.twig
@@ -140,6 +140,22 @@
                         "optgroup":"From PBS API",
                         "label":"From PBS API"
                     },
+	                  {
+                        "value":"premiered_on",
+                        "label":"premiered_on"
+                    },
+                    {
+                        "value":"episodes_count",
+                        "label":"episodes_count"
+                    },
+                    {
+                        "value":"links",
+                        "label":"links"
+                    },
+                    {
+                        "value":"featured_preview",
+                        "label":"featured_preview"
+                    },
                     {
                         "value":"description_short",
                         "label":"description_short"

--- a/src/templates/settings/_apicolumnfields.twig
+++ b/src/templates/settings/_apicolumnfields.twig
@@ -27,7 +27,7 @@
         options: allusers,
         errors: settings.getErrors( 'apiCraftUser' )
     }) }}
-    
+
     {{ forms.textField({
         required: true,
         name: 'apiBaseUrl',
@@ -49,8 +49,8 @@
         rows: settings.apiColumnFields,
         errors: settings.getErrors( 'apiColumnFields' ),
         cols: [
-            { 
-                heading: 'API Field', 
+            {
+                heading: 'API Field',
                 handle: 'apiField',
                 width: '20%',
                 type: 'select',
@@ -63,32 +63,32 @@
                         {"value":"slug","label":"slug"},{"value":"title","label":"title"},{"value":"title_sortable","label":"title_sortable"},{"value":"description_short","label":"description_short"},{"value":"description_long","label":"description_long"},{"value":"object_type","label":"object_type"},{"value":"premiered_on","label":"premiered_on"},{"value":"encored_on","label":"encored_on"},{"value":"is_excluded_from_dfp","label":"is_excluded_from_dfp"},{"value":"duration","label":"duration"},{"value":"content_rating","label":"content_rating"},{"value":"content_rating_descriptor","label":"content_rating_descriptor"},{"value":"can_embed_player","label":"can_embed_player"},{"value":"tags","label":"tags"},{"value":"language","label":"language"},{"value":"funder_message","label":"funder_message"},{"value":"images","label":"images"},{"value":"updated_at","label":"updated_at"},{"value":"countries","label":"countries"},{"value":"geo_profile","label":"geo_profile"},{"value":"topics","label":"topics"},{"value":"platforms","label":"platforms"},{"value":"player_code","label":"player_code"},{"value":"availabilities","label":"availabilities"},{"value":"related_links","label":"related_links"},{"value":"related_promos","label":"related_promos"},{"value":"parent_tree","label":"parent_tree"},{"value":"has_captions","label":"has_captions"}
                 ]
             },
-            { 
-                heading: 'Use existing Craft Field', 
+            {
+                heading: 'Use existing Craft Field',
                 handle: 'existingField',
                 info: 'If selected, you dont need to fill <strong>Craft Field Name</strong>, <strong>Craft Field Handle</strong> and <strong>Craft Field Type</strong>.',
                 width: '20%',
                 type: 'select',
                 options: existingFields
             },
-            { 
-                heading: 'Craft Field Name', 
+            {
+                heading: 'Craft Field Name',
                 handle: 'fieldName',
                 info: 'If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
                 type: 'singleline',
                 placeholder: 'Field Name'
             },
-            { 
-                heading: 'Craft Field Handle', 
+            {
+                heading: 'Craft Field Handle',
                 handle: 'fieldHandle',
                 info: 'Make sure field handle is in camelCase format and unique, existing field with same Field Handle will be used if found. If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
                 type: 'singleline',
                 placeholder: 'Field Name'
             },
-            { 
-                heading: 'Craft Field Type', 
+            {
+                heading: 'Craft Field Type',
                 handle: 'fieldType',
                 info: 'If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
@@ -113,45 +113,77 @@
         rows: settings.showApiColumnFields,
         errors: settings.getErrors( 'showApiColumnFields' ),
         cols: [
-            { 
-                heading: 'API Field', 
+            {
+                heading: 'API Field',
                 handle: 'apiField',
                 width: '20%',
                 type: 'select',
                 options: [
                     {"label":"— Select Field —"},
-                    {"optgroup":"Special Field","label":"Special Field"},
-                        {"value":"show_images","label":"Images"},{"value":"show_last_synced","label":"Last Synced"},{"value":"show_media_manager_id","label":"Media Manager ID"},
-                    {"optgroup":"From PBS API","label":"From PBS API"},
-                        {"value":"description_short","label":"description_short"},{"value":"description_long","label":"description_long"}
+                    {
+                        "optgroup":"Special Field",
+                        "label":"Special Field"
+                    },
+                    {
+                        "value":"show_images",
+                        "label":"Images"
+                    },
+                    {
+                        "value":"show_last_synced",
+                        "label":"Last Synced"
+                    },
+                    {
+                        "value":"show_media_manager_id",
+                        "label":"Media Manager ID"
+                    },
+                    {
+                        "optgroup":"From PBS API",
+                        "label":"From PBS API"
+                    },
+                    {
+                        "value":"description_short",
+                        "label":"description_short"
+                    },
+                    {
+                        "value":"description_long",
+                        "label":"description_long"
+                    },
+                    {
+                        "value":"show_site_url",
+                        "label":"Show Site URL"
+                    },
+                    {
+                        "value":"available_for_purchase",
+                        "label":"Available for Purchase"
+                    }
                 ]
             },
-            { 
-                heading: 'Use existing Craft Field', 
+            {
+                heading: 'Use existing Craft Field',
                 handle: 'existingField',
                 info: 'If selected, you dont need to fill <strong>Craft Field Name</strong>, <strong>Craft Field Handle</strong> and <strong>Craft Field Type</strong>.',
                 width: '20%',
                 type: 'select',
                 options: existingFields
             },
-            { 
-                heading: 'Craft Field Name', 
+            {
+                heading: 'Craft Field Name',
                 handle: 'fieldName',
                 info: 'If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
                 type: 'singleline',
                 placeholder: 'Field Name'
             },
-            { 
-                heading: 'Craft Field Handle', 
+            {
+                heading: 'Craft Field Handle',
                 handle: 'fieldHandle',
                 info: 'Make sure field handle is in camelCase format and unique, existing field with same Field Handle will be used if found. If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
                 type: 'singleline',
                 placeholder: 'Field Name'
             },
-            { 
-                heading: 'Craft Field Type', 
+            {
+                heading: 'Craft Field Type',
                 handle: 'fieldType',
                 info: 'If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',

--- a/src/templates/synchronize.twig
+++ b/src/templates/synchronize.twig
@@ -56,7 +56,7 @@
 {% endblock %}
 
 {% set content %}
-    
+
     {% if not craft.mediaManagerReady() %}
         {% include 'mediamanager/_settingsrequired' %}
     {% else %}
@@ -64,21 +64,9 @@
 
             {% switch activeShow.id %}
                 {% case 'all' %}
-                
-                    <div class="field first" id="group-field">
-                        <div class="heading">
-                            <label id="group-label" for="group">Synchronize All Show : {{ validatedShows }} valid show{{ validatedShows > 1 ? 's' : '' }} available to sync</label><br><br>
-                        </div>
+                    {% set apiColumnFields = craft.app.getPlugins().getPlugin( 'mediamanager' ).getSettings().apiColumnFields %}
 
-                        {% if validatedShows | length %}
-                        <ol>
-                            {% for show in shows %}
-                                {% if show.apiKey %}
-                                    <li>{{ show.name }}</li>
-                                {% endif %}
-                            {% endfor %}
-                        </ol><br/>
-                        {% endif %}
+                    <div class="field first" id="group-field">
 
                         {{ forms.checkboxField({
                             first: false,
@@ -91,16 +79,49 @@
                             autofocus: true,
                             required: false,
                         }) }}
+
+                        {% set fieldsToSyncMap = {
+                            'title': 'Title'
+                        } %}
+
+                        {% for apiColumnField in apiColumnFields %}
+                            {% set fieldsToSyncMap = fieldsToSyncMap|merge({(apiColumnField[0]): apiColumnField[2]}) %}
+                        {% endfor %}
+
+                        {{ forms.checkboxSelectField({
+                            id: 'fieldsToSync',
+                            name: 'fieldsToSync',
+                            label: 'Fields to Sync',
+                            showAllOption: true,
+                            options: fieldsToSyncMap,
+                            values: '*',
+                            instructions: 'Choose which fields you would like to be updated during this sync.',
+                        }) }}
+
+                        <div class="heading">
+                            <label id="group-label" for="group">Synchronize All Show : {{ validatedShows }} valid show{{ validatedShows > 1 ? 's' : '' }} available to sync</label><br><br>
+                        </div>
+
+                        {% if validatedShows | length %}
+                            <ol>
+                                {% for show in shows %}
+                                    {% if show.apiKey %}
+                                        <li>{{ show.name }}</li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ol><br/>
+                        {% endif %}
+
                         <div class="heading">
                             <div class="instructions"><p>Clicking the button below will retrieve Assets from PBS API and update associated Media entries with the latest data.</p></div>
                             <div class="instructions"><p>After clicking, please wait until the blue notification is visible. It may take a while.</p></div>
                         </div>
                     </div>
 
-                    <div id="syncrhonizeallbtn" class="btn submit" tabindex="1">{{ 'Update All Media'|t('media-manager') }}</div>
-
+                    <div id="synchronize-all-button" class="btn submit" tabindex="1">{{ 'Update All Media'|t('media-manager') }}</div>
+										{% set title = 'Synchronize All Shows' %}
                 {% case 'single' %}
-                
+
                     <div class="field first" id="group-field">
                         <div class="heading">
                             <label id="group-label" for="group">Synchronize Single Media</label><br><br>
@@ -111,8 +132,8 @@
 
                     {{ forms.textField({
                         first: true,
-                        label: "Media Asset Content ID"|t('media-manager'),
-                        instructions: "PBS Media Content ID used by this media asset."|t('media-manager'),
+                        label: "Media Asset API Key"|t('media-manager'),
+                        instructions: "PBS Media API Key used by this media asset."|t('media-manager'),
                         id: 'apiKey',
                         name: 'apiKey',
                         value: activeShow.apiKey,
@@ -121,16 +142,7 @@
                         autofocus: true,
                         required: true,
                     }) }}
-                    {{ forms.checkboxField({
-                        first: false,
-                        label: "Force regenerate thumbnail"|t('media-manager'),
-                        instructions: "System will replace existing thumbnail if Media Asset already exists."|t('media-manager'),
-                        id: 'forceRegenerateThumbnail',
-                        name: 'forceRegenerateThumbnail',
-                        errors: '',
-                        autofocus: true,
-                        required: false,
-                    }) }}
+
                     {{ forms.selectField({
                         first: false,
                         label: "Media Asset's Site",
@@ -143,32 +155,91 @@
                     }) }}
 
                     <div id="addshowsite" class="btn add icon" tabindex="0">Add Show's Site</div> <br/><br/>
-                    <div id="syncrhonizesinglebtn" class="btn submit" tabindex="1">{{ 'Update Media'|t('media-manager') }}</div>
 
+                    {{ forms.checkboxField({
+                        first: false,
+                        label: "Force regenerate thumbnail"|t('media-manager'),
+                        instructions: "System will replace existing thumbnail if Media Asset already exists."|t('media-manager'),
+                        id: 'forceRegenerateThumbnail',
+                        name: 'forceRegenerateThumbnail',
+                        errors: '',
+                        autofocus: true,
+                        required: false,
+                    }) }}
+
+                    {% set apiColumnFields = craft.app.getPlugins().getPlugin( 'mediamanager' ).getSettings().apiColumnFields %}
+
+                    {% set fieldsToSyncMap = {
+                        'title': 'Title'
+                    } %}
+
+                    {% for apiColumnField in apiColumnFields %}
+                        {% set fieldsToSyncMap = fieldsToSyncMap|merge({(apiColumnField[0]): apiColumnField[2]}) %}
+                    {% endfor %}
+
+                    {{ forms.checkboxSelectField({
+                        id: 'fieldsToSync',
+                        name: 'fieldsToSync',
+                        label: 'Fields to Sync',
+                        showAllOption: true,
+                        options: fieldsToSyncMap,
+                        values: '*',
+                        instructions: 'Choose which fields you would like to be updated during this sync.',
+                    }) }}
+
+                    <div id="synchronize-single-button" class="btn submit" tabindex="1">{{ 'Update Media'|t('media-manager') }}</div>
+										{% set title = 'Synchronize Single Media' %}
                 {% case 'show-entries' %}
-                
+
                     <div class="field first" id="group-field">
+
+                        {% set fieldsToSyncMap = {
+                            'title': 'Title'
+                        } %}
+
+                        {% set apiColumnFields = craft.app.getPlugins().getPlugin( 'mediamanager' ).getSettings().showApiColumnFields %}
+
+                        {% for apiColumnField in apiColumnFields %}
+                            {% set title = apiColumnField[2] %}
+                            {% if title == '' %}
+                                {% set title = apiColumnField[1] %}
+                            {% endif %}
+                            {% set fieldsToSyncMap = fieldsToSyncMap|merge({(apiColumnField[0]): title}) %}
+                        {% endfor %}
+
+                        {{ forms.checkboxSelectField({
+                            id: 'fieldsToSync',
+                            name: 'fieldsToSync',
+                            label: 'Fields to Sync',
+                            showAllOption: true,
+                            options: fieldsToSyncMap,
+                            values: '*',
+                            instructions: 'Choose which fields you would like to be updated during this sync.',
+                        }) }}
+
                         <div class="heading">
                             <label id="group-label" for="group">Synchronize Show Entries : {{ validatedShows }} valid show{{ validatedShows > 1 ? 's' : '' }} available to sync</label><br><br>
                         </div>
 
                         {% if validatedShows | length %}
-                        <ol>
-                            {% for show in shows %}
-                                {% if show.apiKey %}
-                                    <li>{{ show.name }}</li>
-                                {% endif %}
-                            {% endfor %}
-                        </ol><br/>
+                            <ol>
+                                {% for show in shows %}
+                                    {% if show.apiKey %}
+                                        <li>{{ show.name }}</li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ol><br/>
                         {% endif %}
                     </div>
 
-                    <div id="syncrhonizeshowentriesbtn" class="btn submit" tabindex="1">{{ 'Synchronize Show Entries'|t('media-manager') }}</div>
-
+                    <div id="synchronize-show-entries-button" class="btn submit" tabindex="1">{{ 'Synchronize Show Entries'|t('media-manager') }}</div>
+										{% set title = 'Synchronize Show Entries' %}
                 {% default %}
 
+                    {% set apiColumnFields = craft.app.getPlugins().getPlugin( 'mediamanager' ).getSettings().apiColumnFields %}
+
                     {% if activeShow.apiKey | length %}
-                
+
                         <div class="field first" id="group-field">
                             <div class="heading">
                                 <label id="group-label" for="group">Synchronize Media Entries : {{ activeShow.name }}</label><br><br>
@@ -184,6 +255,27 @@
                                 autofocus: true,
                                 required: false,
                             }) }}
+
+                            <hr>
+
+                            {% set fieldsToSyncMap = {
+                                'title': 'Title'
+                            } %}
+
+                            {% for apiColumnField in apiColumnFields %}
+                                {% set fieldsToSyncMap = fieldsToSyncMap|merge({(apiColumnField[0]): apiColumnField[2]}) %}
+                            {% endfor %}
+
+                            {{ forms.checkboxSelectField({
+                                id: 'fieldsToSync',
+                                name: 'fieldsToSync',
+                                label: 'Fields to Sync',
+                                showAllOption: true,
+                                options: fieldsToSyncMap,
+                                values: '*',
+                                instructions: 'Choose which fields you would like to be updated during this sync.',
+                            }) }}
+
                             <div class="heading">
                                 <div class="instructions"><p>By clicking button bellow will retrieve Assets from PBS API and update associated Media entries with latest data.</p></div>
                                 <div class="instructions"><p>After clicking, please wait until blue notification visible, it may takes a while.</p></div>
@@ -199,19 +291,20 @@
                             name: 'name',
                             value: activeShow.name
                         }) }}
-                        <div id="syncrhonizeshowbtn" class="btn submit" tabindex="1">{{ 'Update All Media'|t('media-manager') }}</div>
-                        
+                        <div id="synchronizeshowbtn" class="btn submit" tabindex="1">{{ 'Update All Media'|t('media-manager') }}</div>
+
                     {% else %}
                         {% if not activeShow.id and not activeShow.apiKey and not activeShow.name and not activeShow.siteId %}
                             Nothing to see here, you might want to create New Show first. <br/><br/>
                             <a href="{{ url(pluginCpUrl) ~ '/shows/' }}" class="btn submit">Create New Show</a>
                         {% else %}
-                            To start Synchronize, you need to set a valid Content ID for <strong>{{ activeShow.name }}</strong> first. <br/><br/>
-                            <a href="{{ url(pluginCpUrl) ~ '/shows/' ~ activeShow.id }}" class="btn submit">Set Content ID Now</a>
+                            To start Synchronize, you need to set a valid API ID for <strong>{{ activeShow.name }}</strong> first. <br/><br/>
+                            <a href="{{ url(pluginCpUrl) ~ '/shows/' ~ activeShow.id }}" class="btn submit">Set API Key Now</a>
                         {% endif %}
                     {% endif %}
             {% endswitch %}
-            
+
+						{% set title = 'Synchronize' %}
         {% else %}
             Nothing to see here, you might want to create New Show first.
         {% endif %}


### PR DESCRIPTION
### Added

- You can now select what fields should be updated during a sync.
- Added more API attributes to the list of fields that can be synchronized to Show entries.
- Show Entry sync jobs can now sync the Passport availability and public availability flags.
- The plugin now emits its own log files for better debugging.

### Changed

- **New** Media entries and Show entries added during a sync will always synchronize all fields, regardless of what fields were selected for sync.
- The way a show's "Episode Count" property is determined now looks at a show's asset count rather than the static "Episode Count" property on the Show record.